### PR TITLE
Run tests on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,3 +139,17 @@ jobs:
 
       - name: swift test
         run: swift test
+
+  windows_tests:
+    name: Windows Tests
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          branch: "swift-5.10.0-release"
+          tag: "5.10.0-RELEASE"
+
+      - name: swift test
+        run: swift test


### PR DESCRIPTION
This may not work and still be blocked by https://github.com/apple/swift-package-manager/issues/6367.

Would close #5.