### PR TITLE
Don't include static properties in conformance.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,21 @@
 {
   "pins" : [
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
       "identity" : "swift-macro-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "15916c0c328339f54c15d616465d79700e3f7de8"
+        "revision" : "0b80a098d4805a21c412b65f01ffde7b01aab2fa",
+        "version" : "0.6.0"
       }
     },
     {
@@ -14,17 +23,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "8e68404f641300bfd0e37d478683bb275926760c",
-        "version" : "1.15.2"
+        "revision" : "b2d4cb30735f4fbc3a01963a9c658336dd21e9ba",
+        "version" : "1.18.1"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/apple/swift-syntax",
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,14 +19,10 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(
-      url: "https://github.com/apple/swift-syntax.git",
-      from: "509.1.0"
-    ),
-    .package(
-        url: "https://github.com/pointfreeco/swift-macro-testing.git",
-        branch: "main" // Needed to test diagnostics. 0.2.3 or higher should be ok.
-    ),
+    .package(url: "https://github.com/apple/swift-syntax", from: "509.1.0"),
+    // We only really need swift-macro-testing 0.3.0 or newer but 0.4.0 is required to compile due
+    // to breaking changes in swift-snapshot-testing.
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.4.0"),
   ],
   targets: [
     .target(

--- a/Sources/HashableMacroMacros/Macros/HashableMacro.swift
+++ b/Sources/HashableMacroMacros/Macros/HashableMacro.swift
@@ -17,7 +17,7 @@ public struct HashableMacro: ExtensionMacro {
         guard !declaration.is(EnumDeclSyntax.self) else {
             throw HashableMacroDiagnosticMessage(
                 id: "enum-not-supported",
-                message: "'Hashable' is not currently supported on enums.",
+                message: "'@Hashable' is not currently supported on enums.",
                 severity: .error
             )
         }

--- a/Sources/HashableMacroMacros/Macros/HashableMacro.swift
+++ b/Sources/HashableMacroMacros/Macros/HashableMacro.swift
@@ -91,21 +91,21 @@ public struct HashableMacro: ExtensionMacro {
             }
         }
 
-        let properties = declaration.memberBlock.members
+        let hashedVariableCandidates = declaration.memberBlock.members
             .compactMap { $0.decl.as(VariableDeclSyntax.self) }
             .filter(HashedMacro.isSupportedOnVariable(_:))
         var explicitlyHashedProperties: [TokenSyntax] = []
         var undecoratedProperties: [TokenSyntax] = []
         var notHashedAttributes: [AttributeSyntax] = []
 
-        for property in properties {
-            let bindings = property.bindings.compactMap({ binding in
+        for variable in hashedVariableCandidates {
+            let bindings = variable.bindings.compactMap({ binding in
                 binding
                     .pattern
                     .as(IdentifierPatternSyntax.self)?
                     .identifier
             })
-            lazy var isCalculated = property.bindings.contains { binding in
+            lazy var isCalculated = variable.bindings.contains { binding in
                 guard let accessorBlock = binding.accessorBlock else { return false }
                 switch accessorBlock.accessors {
                 case .getter:
@@ -124,7 +124,7 @@ public struct HashableMacro: ExtensionMacro {
             }
 
             func attribute(named macroName: String) -> AttributeSyntax? {
-                for attribute in property.attributes {
+                for attribute in variable.attributes {
                     guard let attribute = attribute.as(AttributeSyntax.self) else { continue }
                     let identifier = attribute
                         .attributeName

--- a/Sources/HashableMacroMacros/Macros/HashableMacro.swift
+++ b/Sources/HashableMacroMacros/Macros/HashableMacro.swift
@@ -91,7 +91,9 @@ public struct HashableMacro: ExtensionMacro {
             }
         }
 
-        let properties = declaration.memberBlock.members.compactMap({ $0.decl.as(VariableDeclSyntax.self) })
+        let properties = declaration.memberBlock.members
+            .compactMap({ $0.decl.as(VariableDeclSyntax.self) })
+            .filter { property in property.modifiers.first(where: { $0.name.text == "static" }) == nil } // filter out static properties
         var explicitlyHashedProperties: [TokenSyntax] = []
         var undecoratedProperties: [TokenSyntax] = []
         var notHashedAttributes: [AttributeSyntax] = []

--- a/Sources/HashableMacroMacros/Macros/HashableMacro.swift
+++ b/Sources/HashableMacroMacros/Macros/HashableMacro.swift
@@ -92,8 +92,8 @@ public struct HashableMacro: ExtensionMacro {
         }
 
         let properties = declaration.memberBlock.members
-            .compactMap({ $0.decl.as(VariableDeclSyntax.self) })
-            .filter { property in property.modifiers.first(where: { $0.name.text == "static" }) == nil } // filter out static properties
+            .compactMap { $0.decl.as(VariableDeclSyntax.self) }
+            .filter(HashedMacro.isSupportedOnVariable(_:))
         var explicitlyHashedProperties: [TokenSyntax] = []
         var undecoratedProperties: [TokenSyntax] = []
         var notHashedAttributes: [AttributeSyntax] = []

--- a/Sources/HashableMacroMacros/Macros/HashedMacro.swift
+++ b/Sources/HashableMacroMacros/Macros/HashedMacro.swift
@@ -1,3 +1,4 @@
+import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
 
@@ -9,7 +10,65 @@ public struct HashedMacro: PeerMacro {
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
+        guard let variable = declaration.as(VariableDeclSyntax.self) else {
+            let fixIt = FixIt(
+                message: HashableMacroFixItMessage(
+                    id: "hashed-added-to-unsupported-node",
+                    message: "Remove @Hashed"
+                ),
+                changes: [
+                    FixIt.Change.replace(
+                        oldNode: Syntax(node),
+                        newNode: Syntax("" as DeclSyntax)
+                    )
+                ]
+            )
+            let diagnostic = Diagnostic(
+                node: Syntax(node),
+                message: HashableMacroDiagnosticMessage(
+                    id: "hashed-added-to-unsupported-node",
+                    message: "The @Hashed macro is only supported on properties.",
+                    severity: .warning
+                ),
+                fixIt: fixIt
+            )
+            context.diagnose(diagnostic)
+            return []
+        }
+
+        if !isSupportedOnVariable(variable) {
+            let fixIt = FixIt(
+                message: HashableMacroFixItMessage(
+                    id: "hashed-added-to-unsupported-variable",
+                    message: "Remove @Hashed"
+                ),
+                changes: [
+                    FixIt.Change.replace(
+                        oldNode: Syntax(node),
+                        newNode: Syntax("" as DeclSyntax)
+                    )
+                ]
+            )
+            let diagnostic = Diagnostic(
+                node: Syntax(node),
+                message: HashableMacroDiagnosticMessage(
+                    id: "hashed-added-to-unsupported-variable",
+                    message: "The @Hashed macro is only supported on instance properties.",
+                    severity: .warning
+                ),
+                fixIt: fixIt
+            )
+            context.diagnose(diagnostic)
+        }
+
         // Only used to decorate members
         return []
+    }
+
+    public static func isSupportedOnVariable(_ variable: VariableDeclSyntax) -> Bool {
+        variable.modifiers.allSatisfy { modifier in
+            let tokenKind = modifier.name.trimmed.tokenKind
+            return tokenKind != .keyword(.static) && tokenKind != .keyword(.class)
+        }
     }
 }

--- a/Sources/HashableMacroMacros/Macros/NotHashedMacro.swift
+++ b/Sources/HashableMacroMacros/Macros/NotHashedMacro.swift
@@ -1,3 +1,4 @@
+import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
 
@@ -9,7 +10,65 @@ public struct NotHashedMacro: PeerMacro {
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
+        guard let variable = declaration.as(VariableDeclSyntax.self) else {
+            let fixIt = FixIt(
+                message: HashableMacroFixItMessage(
+                    id: "not-hashed-added-to-unsupported-node",
+                    message: "Remove @NotHashed"
+                ),
+                changes: [
+                    FixIt.Change.replace(
+                        oldNode: Syntax(node),
+                        newNode: Syntax("" as DeclSyntax)
+                    )
+                ]
+            )
+            let diagnostic = Diagnostic(
+                node: Syntax(node),
+                message: HashableMacroDiagnosticMessage(
+                    id: "nothashed-added-to-unsupported-node",
+                    message: "The @NotHashed macro is only supported on properties.",
+                    severity: .warning
+                ),
+                fixIt: fixIt
+            )
+            context.diagnose(diagnostic)
+            return []
+        }
+
+        if !isSupportedOnVariable(variable) {
+            let fixIt = FixIt(
+                message: HashableMacroFixItMessage(
+                    id: "not-hashed-added-to-unsupported-variable",
+                    message: "Remove @NotHashed"
+                ),
+                changes: [
+                    FixIt.Change.replace(
+                        oldNode: Syntax(node),
+                        newNode: Syntax("" as DeclSyntax)
+                    )
+                ]
+            )
+            let diagnostic = Diagnostic(
+                node: Syntax(node),
+                message: HashableMacroDiagnosticMessage(
+                    id: "not-hashed-added-to-unsupported-variable",
+                    message: "The @NotHashed macro is only supported on instance properties.",
+                    severity: .warning
+                ),
+                fixIt: fixIt
+            )
+            context.diagnose(diagnostic)
+        }
+
         // Only used to decorate members
         return []
+    }
+
+    public static func isSupportedOnVariable(_ variable: VariableDeclSyntax) -> Bool {
+        variable.modifiers.allSatisfy { modifier in
+            let tokenKind = modifier.name.trimmed.tokenKind
+            return tokenKind != .keyword(.static) && tokenKind != .keyword(.class)
+        }
     }
 }

--- a/Tests/HashableMacroTests/HashableMacroAPITests.swift
+++ b/Tests/HashableMacroTests/HashableMacroAPITests.swift
@@ -36,6 +36,12 @@ private struct PrivateStruct {
 }
 
 @Hashable
+private struct StructWithReservedNames {
+    private let hasher = "hasher"
+    private let hash = 123
+}
+
+@Hashable
 struct HashableStructWithExplicitlyIncludedProperties {
     @Hashed
     let firstProperty: Int

--- a/Tests/HashableMacroTests/HashableMacroTests.swift
+++ b/Tests/HashableMacroTests/HashableMacroTests.swift
@@ -288,8 +288,8 @@ final class HashableMacroTests: XCTestCase {
         throw XCTSkip("Macros are only supported when running tests for the host platform")
         #endif
     }
-    
-    func testSkipStaticProperties() throws {
+
+    func testSkipStaticPropertiesOnStructs() throws {
         #if canImport(HashableMacroMacros)
         assertMacro(testMacros) {
             """
@@ -319,6 +319,284 @@ final class HashableMacroTests: XCTestCase {
                     return lhs.hashableProperty == rhs.hashableProperty
                 }
             }
+            """
+        }
+        #else
+        throw XCTSkip("Macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testAddingHashedMacroToStaticAndClassVariables() throws {
+        #if canImport(HashableMacroMacros)
+        assertMacro(testMacros) {
+            """
+            @Hashable(_disableNSObjectSubclassSupport: true)
+            class ClassWithStaticAndClassProperties {
+                @Hashed
+                var hashableProperty: String
+                @Hashed
+                static var staticVar: String = "hello"
+                @Hashed
+                static let staticLet: String = "world"
+                @Hashed
+                class var classVar: String = "hello"
+                @Hashed
+                class let classLet: String = "world"
+            }
+            """
+        } diagnostics: {
+            """
+            @Hashable(_disableNSObjectSubclassSupport: true)
+            class ClassWithStaticAndClassProperties {
+                @Hashed
+                var hashableProperty: String
+                @Hashed
+                ┬──────
+                ╰─ ⚠️ The @Hashed macro is only supported on instance properties.
+                   ✏️ Remove @Hashed
+                static var staticVar: String = "hello"
+                @Hashed
+                ┬──────
+                ╰─ ⚠️ The @Hashed macro is only supported on instance properties.
+                   ✏️ Remove @Hashed
+                static let staticLet: String = "world"
+                @Hashed
+                ┬──────
+                ╰─ ⚠️ The @Hashed macro is only supported on instance properties.
+                   ✏️ Remove @Hashed
+                class var classVar: String = "hello"
+                @Hashed
+                ┬──────
+                ╰─ ⚠️ The @Hashed macro is only supported on instance properties.
+                   ✏️ Remove @Hashed
+                class let classLet: String = "world"
+            }
+            """
+        } fixes: {
+            """
+            @Hashable(_disableNSObjectSubclassSupport: true)
+            class ClassWithStaticAndClassProperties {
+                @Hashed
+                var hashableProperty: String
+                static var staticVar: String = "hello"
+                static let staticLet: String = "world"
+                class var classVar: String = "hello"
+                class let classLet: String = "world"
+            }
+            """
+        } expansion: {
+            """
+            class ClassWithStaticAndClassProperties {
+                var hashableProperty: String
+                static var staticVar: String = "hello"
+                static let staticLet: String = "world"
+                class var classVar: String = "hello"
+                class let classLet: String = "world"
+            }
+            
+            extension ClassWithStaticAndClassProperties {
+                final func hash(into hasher: inout Hasher) {
+                    hasher.combine(self.hashableProperty)
+                }
+            }
+            
+            extension ClassWithStaticAndClassProperties {
+                static func ==(lhs: ClassWithStaticAndClassProperties, rhs: ClassWithStaticAndClassProperties) -> Bool {
+                    return lhs.hashableProperty == rhs.hashableProperty
+                }
+            }
+            """
+        }
+        #else
+        throw XCTSkip("Macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testAddingNotHashedMacroToStaticAndClassVariables() throws {
+        #if canImport(HashableMacroMacros)
+        assertMacro(testMacros) {
+            """
+            @Hashable(_disableNSObjectSubclassSupport: true)
+            class ClassWithStaticAndClassProperties {
+                @Hashed
+                var hashableProperty: String
+                @NotHashed
+                static var staticVar: String = "hello"
+                @NotHashed
+                static let staticLet: String = "world"
+                @NotHashed
+                class var classVar: String = "hello"
+                @NotHashed
+                class let classLet: String = "world"
+            }
+            """
+        } diagnostics: {
+            """
+            @Hashable(_disableNSObjectSubclassSupport: true)
+            class ClassWithStaticAndClassProperties {
+                @Hashed
+                var hashableProperty: String
+                @NotHashed
+                ┬─────────
+                ╰─ ⚠️ The @NotHashed macro is only supported on instance properties.
+                   ✏️ Remove @NotHashed
+                static var staticVar: String = "hello"
+                @NotHashed
+                ┬─────────
+                ╰─ ⚠️ The @NotHashed macro is only supported on instance properties.
+                   ✏️ Remove @NotHashed
+                static let staticLet: String = "world"
+                @NotHashed
+                ┬─────────
+                ╰─ ⚠️ The @NotHashed macro is only supported on instance properties.
+                   ✏️ Remove @NotHashed
+                class var classVar: String = "hello"
+                @NotHashed
+                ┬─────────
+                ╰─ ⚠️ The @NotHashed macro is only supported on instance properties.
+                   ✏️ Remove @NotHashed
+                class let classLet: String = "world"
+            }
+            """
+        } fixes: {
+            """
+            @Hashable(_disableNSObjectSubclassSupport: true)
+            class ClassWithStaticAndClassProperties {
+                @Hashed
+                var hashableProperty: String
+                static var staticVar: String = "hello"
+                static let staticLet: String = "world"
+                class var classVar: String = "hello"
+                class let classLet: String = "world"
+            }
+            """
+        } expansion: {
+            """
+            class ClassWithStaticAndClassProperties {
+                var hashableProperty: String
+                static var staticVar: String = "hello"
+                static let staticLet: String = "world"
+                class var classVar: String = "hello"
+                class let classLet: String = "world"
+            }
+            
+            extension ClassWithStaticAndClassProperties {
+                final func hash(into hasher: inout Hasher) {
+                    hasher.combine(self.hashableProperty)
+                }
+            }
+            
+            extension ClassWithStaticAndClassProperties {
+                static func ==(lhs: ClassWithStaticAndClassProperties, rhs: ClassWithStaticAndClassProperties) -> Bool {
+                    return lhs.hashableProperty == rhs.hashableProperty
+                }
+            }
+            """
+        }
+        #else
+        throw XCTSkip("Macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testAddingHashedToUnsupportedDeclarations() {
+        #if canImport(HashableMacroMacros)
+        assertMacro(testMacros) {
+            """
+            @Hashed
+            class ClassWithStaticAndClassProperties {
+                @Hashed
+                func testFunction() {}
+            }
+            
+            @Hashed
+            typealias MyString = String
+            """
+        } diagnostics: {
+            """
+            @Hashed
+            ┬──────
+            ╰─ ⚠️ The @Hashed macro is only supported on properties.
+               ✏️ Remove @Hashed
+            class ClassWithStaticAndClassProperties {
+                @Hashed
+                ┬──────
+                ╰─ ⚠️ The @Hashed macro is only supported on properties.
+                   ✏️ Remove @Hashed
+                func testFunction() {}
+            }
+
+            @Hashed
+            ┬──────
+            ╰─ ⚠️ The @Hashed macro is only supported on properties.
+               ✏️ Remove @Hashed
+            typealias MyString = String
+            """
+        } fixes: {
+            """
+            class ClassWithStaticAndClassProperties {
+                func testFunction() {}
+            }
+            typealias MyString = String
+            """
+        } expansion: {
+            """
+            class ClassWithStaticAndClassProperties {
+                func testFunction() {}
+            }
+            typealias MyString = String
+            """
+        }
+        #else
+        throw XCTSkip("Macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testAddingNotHashedToUnsupportedDeclarations() {
+        #if canImport(HashableMacroMacros)
+        assertMacro(testMacros) {
+            """
+            @NotHashed
+            class ClassWithStaticAndClassProperties {
+                @NotHashed
+                func testFunction() {}
+            }
+            
+            @NotHashed
+            typealias MyString = String
+            """
+        } diagnostics: {
+            """
+            @NotHashed
+            ┬─────────
+            ╰─ ⚠️ The @NotHashed macro is only supported on properties.
+               ✏️ Remove @NotHashed
+            class ClassWithStaticAndClassProperties {
+                @NotHashed
+                ┬─────────
+                ╰─ ⚠️ The @NotHashed macro is only supported on properties.
+                   ✏️ Remove @NotHashed
+                func testFunction() {}
+            }
+
+            @NotHashed
+            ┬─────────
+            ╰─ ⚠️ The @NotHashed macro is only supported on properties.
+               ✏️ Remove @NotHashed
+            typealias MyString = String
+            """
+        } fixes: {
+            """
+            class ClassWithStaticAndClassProperties {
+                func testFunction() {}
+            }
+            typealias MyString = String
+            """
+        } expansion: {
+            """
+            class ClassWithStaticAndClassProperties {
+                func testFunction() {}
+            }
+            typealias MyString = String
             """
         }
         #else

--- a/Tests/HashableMacroTests/HashableMacroTests.swift
+++ b/Tests/HashableMacroTests/HashableMacroTests.swift
@@ -498,7 +498,7 @@ final class HashableMacroTests: XCTestCase {
         #endif
     }
 
-    func testAddingHashedToUnsupportedDeclarations() {
+    func testAddingHashedToUnsupportedDeclarations() throws {
         #if canImport(HashableMacroMacros)
         assertMacro(testMacros) {
             """
@@ -551,7 +551,7 @@ final class HashableMacroTests: XCTestCase {
         #endif
     }
 
-    func testAddingNotHashedToUnsupportedDeclarations() {
+    func testAddingNotHashedToUnsupportedDeclarations() throws {
         #if canImport(HashableMacroMacros)
         assertMacro(testMacros) {
             """

--- a/Tests/HashableMacroTests/HashableMacroTests.swift
+++ b/Tests/HashableMacroTests/HashableMacroTests.swift
@@ -1452,7 +1452,7 @@ final class HashableMacroTests: XCTestCase {
             """
             @Hashable(_disableNSObjectSubclassSupport: true)
             ┬───────────────────────────────────────────────
-            ╰─ 🛑 'Hashable' is not currently supported on enums.
+            ╰─ 🛑 '@Hashable' is not currently supported on enums.
             enum TestEnum {
                 case testCase
             }

--- a/Tests/HashableMacroTests/HashableMacroTests.swift
+++ b/Tests/HashableMacroTests/HashableMacroTests.swift
@@ -288,6 +288,43 @@ final class HashableMacroTests: XCTestCase {
         throw XCTSkip("Macros are only supported when running tests for the host platform")
         #endif
     }
+    
+    func testSkipStaticProperties() throws {
+        #if canImport(HashableMacroMacros)
+        assertMacro(testMacros) {
+            """
+            @Hashable(_disableNSObjectSubclassSupport: true)
+            struct StructWithStaticProperties {
+                var hashableProperty: String
+                static var staticVar: String = "hello"
+                static let staticLet: String
+            }
+            """
+        } expansion: {
+            """
+            struct StructWithStaticProperties {
+                var hashableProperty: String
+                static var staticVar: String = "hello"
+                static let staticLet: String
+            }
+
+            extension StructWithStaticProperties {
+                func hash(into hasher: inout Hasher) {
+                    hasher.combine(self.hashableProperty)
+                }
+            }
+
+            extension StructWithStaticProperties {
+                static func ==(lhs: Self, rhs: Self) -> Bool {
+                    return lhs.hashableProperty == rhs.hashableProperty
+                }
+            }
+            """
+        }
+        #else
+        throw XCTSkip("Macros are only supported when running tests for the host platform")
+        #endif
+    }
 
     func testPackageStruct() throws {
         #if canImport(HashableMacroMacros)


### PR DESCRIPTION
Thank you for this very useful macro!

I've noticed that the conformances include the static properties which is a little over eager IMO.

Please let me know if you have any questions!